### PR TITLE
AJAX FIX v1.24.10: Fix dynamic pricing AJAX 400 error after WooCommerce 10.0.2 update

### DIFF
--- a/apw-woo-plugin.php
+++ b/apw-woo-plugin.php
@@ -11,7 +11,7 @@
  * Plugin Name:       APW WooCommerce Plugin
  * Plugin URI:        https://github.com/OrasesWPDev/apw-woo-plugin
  * Description:       Custom WooCommerce enhancements for displaying products across shop, category, and product pages.
- * Version:           1.24.9
+ * Version:           1.24.10
  * Requires at least: 5.3
  * Tested up to:      6.4
  * Requires PHP:      7.2
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
 /**
  * Plugin constants
  */
-define('APW_WOO_VERSION', '1.24.9');
+define('APW_WOO_VERSION', '1.24.10');
 define('APW_WOO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('APW_WOO_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('APW_WOO_PLUGIN_FILE', __FILE__);

--- a/includes/apw-woo-dynamic-pricing-functions.php
+++ b/includes/apw-woo-dynamic-pricing-functions.php
@@ -661,8 +661,19 @@ function apw_woo_enqueue_dynamic_pricing_scripts()
  */
 function apw_woo_fallback_localization()
 {
-    // Only run on product pages
-    if (!is_product()) {
+    // Only run on product pages (including custom URL structure)
+    $is_product_page = is_product();
+    
+    // Check for custom URL structure if standard check fails
+    if (!$is_product_page && class_exists('APW_Woo_Page_Detector')) {
+        global $wp;
+        $is_product_page = APW_Woo_Page_Detector::is_product_page($wp);
+    }
+    
+    if (!$is_product_page) {
+        if (APW_WOO_DEBUG_MODE) {
+            apw_woo_log('FALLBACK LOCALIZATION: Not a product page, skipping fallback');
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary
- Fixed JavaScript emergency fallback to include proper nonce detection and extraction
- Fixed fallback localization to work with custom URL structures using Page Detector
- Enhanced emergency nonce extraction from WooCommerce params and form fields
- Updated version to 1.24.10

## Root Cause
The dynamic pricing AJAX was failing with 400 Bad Request because:
1. The main wp_localize_script was failing on custom URL structures
2. The fallback localization wasn't running due to `is_product()` check failing
3. The emergency fallback object lacked proper nonce values

## Changes Made
1. **JavaScript Emergency Fallback**: Added nonce detection from WooCommerce params and form fields
2. **PHP Fallback Localization**: Enhanced to work with custom URL structures via Page Detector
3. **Version Bump**: Updated to v1.24.10 for deployment

## Test Plan
- Test dynamic pricing on custom URL structure `/products/routers/inhand-i22/`
- Verify AJAX requests include proper nonce values
- Confirm price updates work correctly when quantity changes
- Test with WooCommerce 10.0.2 compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)