### PR TITLE
DYNAMIC PRICING FIX v1.24.12: Restore missing price display and discount notices

### DIFF
--- a/apw-woo-plugin.php
+++ b/apw-woo-plugin.php
@@ -11,7 +11,7 @@
  * Plugin Name:       APW WooCommerce Plugin
  * Plugin URI:        https://github.com/OrasesWPDev/apw-woo-plugin
  * Description:       Custom WooCommerce enhancements for displaying products across shop, category, and product pages.
- * Version:           1.24.11
+ * Version:           1.24.12
  * Requires at least: 5.3
  * Tested up to:      6.4
  * Requires PHP:      7.2
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
 /**
  * Plugin constants
  */
-define('APW_WOO_VERSION', '1.24.11');
+define('APW_WOO_VERSION', '1.24.12');
 define('APW_WOO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('APW_WOO_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('APW_WOO_PLUGIN_FILE', __FILE__);
@@ -797,6 +797,10 @@ function apw_woo_init()
 
     // PHASE 2: Initialize consolidated Product Service (replaces add-ons and dynamic pricing)
     apw_woo_initialize_product_service();
+
+    // CRITICAL FIX v1.24.12: Restore dynamic pricing initialization that was removed during Phase 2 refactoring
+    // This call is essential for price display and discount notices to work properly
+    apw_woo_init_dynamic_pricing();
 
     // PHASE 2: Initialize consolidated Payment Service (replaces recurring billing and Intuit integration)
     apw_woo_initialize_payment_service();


### PR DESCRIPTION
## Summary
- Restore critical `apw_woo_init_dynamic_pricing()` call that was removed during Phase 2 refactoring
- This function registers essential hooks for price display and discount functionality
- Fixes missing $109.00 price display on product pages (https://allpointstage.wpenginepowered.com/products/routers/inhand-i22/)
- Fixes missing VIP/bulk discount threshold messages

## Root Cause Analysis
The dynamic pricing system initialization was removed during Phase 2 service consolidation but never properly restored. This caused:
- Missing price display hook: `woocommerce_after_add_to_cart_quantity` -> `apw_woo_replace_price_display`
- Missing discount AJAX handlers: `wp_ajax_apw_woo_get_threshold_messages`
- Missing discount application hooks: `woocommerce_before_calculate_totals` -> `apw_woo_apply_role_based_bulk_discounts`

## Technical Details
- **Version Update**: 1.24.11 → 1.24.12
- **Critical Hook Registration**: All dynamic pricing hooks now properly initialized
- **Placement**: Added after Product Service initialization to maintain Phase 2 architecture
- **Backward Compatibility**: Maintains all existing functionality while restoring missing features

## Test Plan
- [x] Price display ($109.00) appears on product pages
- [x] VIP discount notices work for distro10 users
- [x] Bulk discount notices appear at quantity 5+
- [x] All AJAX functionality works correctly
- [x] No JavaScript errors or conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)