### PR TITLE
ORDER CANCELLATION FIX v1.24.13: Fix WooCommerce admin order cancellation error (#54)

### DIFF
--- a/apw-woo-plugin.php
+++ b/apw-woo-plugin.php
@@ -11,7 +11,7 @@
  * Plugin Name:       APW WooCommerce Plugin
  * Plugin URI:        https://github.com/OrasesWPDev/apw-woo-plugin
  * Description:       Custom WooCommerce enhancements for displaying products across shop, category, and product pages.
- * Version:           1.24.12
+ * Version:           1.24.13
  * Requires at least: 5.3
  * Tested up to:      6.4
  * Requires PHP:      7.2
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
 /**
  * Plugin constants
  */
-define('APW_WOO_VERSION', '1.24.12');
+define('APW_WOO_VERSION', '1.24.13');
 define('APW_WOO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('APW_WOO_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('APW_WOO_PLUGIN_FILE', __FILE__);

--- a/includes/apw-woo-dynamic-pricing-functions.php
+++ b/includes/apw-woo-dynamic-pricing-functions.php
@@ -1523,14 +1523,8 @@ function apw_woo_reapply_admin_discounts_before_calc($and_taxes, $order) {
             // This ensures tax is calculated even if the after_calculate_totals hook doesn't fire
             $fee_total = $fee->get_total();
             if ($fee_total < 0) { // Only for discount fees
-                // HOT FIX v1.24.4: Build tax address from order data (get_tax_address() doesn't exist on Order objects)
-                $tax_address = array(
-                    'country'  => $order->get_billing_country() ?: $order->get_shipping_country(),
-                    'state'    => $order->get_billing_state() ?: $order->get_shipping_state(),
-                    'postcode' => $order->get_billing_postcode() ?: $order->get_shipping_postcode(),
-                    'city'     => $order->get_billing_city() ?: $order->get_shipping_city()
-                );
-                $tax_rates = WC_Tax::get_rates($fee->get_tax_class(), $tax_address);
+                // FIX v1.24.13: Use order's get_tax_address() method instead of manual array construction
+                $tax_rates = WC_Tax::get_rates($fee->get_tax_class(), $order->get_tax_address());
                 $fee_taxes = WC_Tax::calc_tax(abs($fee_total), $tax_rates, false);
                 
                 if (!empty($fee_taxes)) {


### PR DESCRIPTION
## Summary
- Fixed fatal error when canceling orders in WooCommerce admin dashboard
- Error: "Call to a member function get_taxable_address() on array" in dynamic pricing functions
- Replaced manual tax address array construction with WooCommerce's built-in get_tax_address() method

## Root Cause
The `WC_Tax::get_rates()` method expected a customer object or specific array format, but received an associative array that caused it to call `get_taxable_address()` on an array instead of an object.

## Test Plan
- [ ] Test order cancellation in WooCommerce admin dashboard
- [ ] Verify discount tax calculations still work correctly  
- [ ] Confirm no regression in existing VIP/bulk discount functionality
- [ ] Test with different order states and payment methods

🤖 Generated with [Claude Code](https://claude.ai/code)