### PR TITLE
FIX: Use correct WooCommerce tax method for Admin Overrides Order

### DIFF
--- a/apw-woo-plugin.php
+++ b/apw-woo-plugin.php
@@ -11,7 +11,7 @@
  * Plugin Name:       APW WooCommerce Plugin
  * Plugin URI:        https://github.com/OrasesWPDev/apw-woo-plugin
  * Description:       Custom WooCommerce enhancements for displaying products across shop, category, and product pages.
- * Version:           1.24.14
+ * Version:           1.24.15
  * Requires at least: 5.3
  * Tested up to:      6.4
  * Requires PHP:      7.2
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
 /**
  * Plugin constants
  */
-define('APW_WOO_VERSION', '1.24.14');
+define('APW_WOO_VERSION', '1.24.15');
 define('APW_WOO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('APW_WOO_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('APW_WOO_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Fix Tax Address Error for Admin Overrides Order

### Problem
The Phase 1 fix (v1.24.14) failed because `WC_Tax::get_rates()` expects a customer object as the second parameter, but our compatibility helper was returning an array. This caused the error:
```
Call to a member function get_taxable_address() on array
```

### Root Cause
- `WC_Tax::get_rates($tax_class, $customer)` expects a customer object with `get_taxable_address()` method
- `apw_woo_get_compatible_tax_address()` was returning an array instead of a customer object
- WooCommerce's tax system tried to call `get_taxable_address()` on the array, causing the error

### Solution
Created a comprehensive tax rate helper that uses the appropriate WooCommerce method based on order type:

1. **Standard WC_Order**: Uses `WC_Tax::get_rates($tax_class, null)` - lets WooCommerce handle customer detection
2. **Admin Overrides Order**: Uses `WC_Tax::get_rates_from_location($tax_class, $location)` with indexed location array

### Implementation Details

#### New Helper Function
```php
function apw_woo_get_tax_rates_for_order($tax_class, $order) {
    if (method_exists($order, 'get_tax_address')) {
        // Standard WC_Order - use get_rates
        return WC_Tax::get_rates($tax_class, null);
    }
    
    // Admin Overrides Order - use get_rates_from_location
    $location = apw_woo_get_compatible_tax_address($order);
    return WC_Tax::get_rates_from_location($tax_class, $location);
}
```

#### Updated Tax Address Format
Modified `apw_woo_get_compatible_tax_address()` to return indexed array format `[country, state, postcode, city]` required by `WC_Tax::get_rates_from_location()`.

### Changes Made
- **File**: `includes/apw-woo-dynamic-pricing-functions.php`
- **Lines Updated**: 1570 and 1655 (replaced problematic calls)
- **Version**: Updated to v1.24.15 (new version since v1.24.14 was merged)

### Testing
- [x] Syntax validation passed for both modified files
- [x] Uses correct WooCommerce tax methods for each order type
- [x] Maintains backward compatibility with standard WC_Order
- [x] Properly handles Admin Overrides Order without `get_tax_address()` method

### Expected Outcome
- ✅ Admin order cancellation works without errors
- ✅ Tax calculations remain accurate for both order types
- ✅ No more "Call to a member function get_taxable_address() on array" errors
- ✅ Ready for Phase 2 implementation (eliminate duplicate code)

🤖 Generated with [Claude Code](https://claude.ai/code)