### PR TITLE
FEATURE v1.24.16: Product-specific threshold notifications

### DIFF
--- a/apw-woo-plugin.php
+++ b/apw-woo-plugin.php
@@ -11,7 +11,7 @@
  * Plugin Name:       APW WooCommerce Plugin
  * Plugin URI:        https://github.com/OrasesWPDev/apw-woo-plugin
  * Description:       Custom WooCommerce enhancements for displaying products across shop, category, and product pages.
- * Version:           1.24.15
+ * Version:           1.24.16
  * Requires at least: 5.3
  * Tested up to:      6.4
  * Requires PHP:      7.2
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
 /**
  * Plugin constants
  */
-define('APW_WOO_VERSION', '1.24.15');
+define('APW_WOO_VERSION', '1.24.16');
 define('APW_WOO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('APW_WOO_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('APW_WOO_PLUGIN_FILE', __FILE__);

--- a/assets/css/apw-woo-threshold-messages.css
+++ b/assets/css/apw-woo-threshold-messages.css
@@ -188,3 +188,19 @@
     background-color: #bbdefb;
     border-color: #1565c0;
 }
+
+/* Billing threshold message styling */
+.apw-threshold-billing {
+    background-color: #fff8e1;
+    border: 1px solid #ffc107;
+    color: #e65100;
+}
+
+.apw-threshold-billing .message-icon {
+    color: #ffc107;
+}
+
+.apw-threshold-billing.achieved {
+    background-color: #fff3c4;
+    border-color: #ff8f00;
+}

--- a/includes/apw-woo-dynamic-pricing-functions.php
+++ b/includes/apw-woo-dynamic-pricing-functions.php
@@ -1336,14 +1336,27 @@ function apw_woo_simulate_bulk_discount_thresholds($product_id, $quantity) {
         );
     }
 
-    // Add shipping threshold if quantity is 10+
-    $shipping_threshold = apply_filters('apw_woo_free_shipping_threshold', 10, $product_id);
-    if ($quantity >= $shipping_threshold) {
-        $messages[] = array(
-            'type' => 'shipping',
-            'message' => 'Free ground shipping at qty ' . $shipping_threshold,
-            'threshold' => $shipping_threshold
-        );
+    // Product-specific threshold messages
+    if ((int)$product_id === 80) {
+        // I-22 Wireless Router - 4-month delayed billing at qty 10+
+        $shipping_threshold = apply_filters('apw_woo_free_shipping_threshold', 10, $product_id);
+        if ($quantity >= $shipping_threshold) {
+            $messages[] = array(
+                'type' => 'billing',
+                'message' => 'Orders of 10 or more grants 4-month delayed billing.',
+                'threshold' => $shipping_threshold
+            );
+        }
+    } elseif ((int)$product_id === 647) {
+        // Cudy LT400 Wireless Router - Free shipping at qty 5+
+        $shipping_threshold = apply_filters('apw_woo_free_shipping_threshold', 5, $product_id);
+        if ($quantity >= $shipping_threshold) {
+            $messages[] = array(
+                'type' => 'shipping',
+                'message' => 'Free ground shipping at qty ' . $shipping_threshold,
+                'threshold' => $shipping_threshold
+            );
+        }
     }
 
     if (APW_WOO_DEBUG_MODE) {


### PR DESCRIPTION
## Summary
This PR implements product-specific threshold notifications, replacing the previous universal shipping threshold with targeted rules for specific products.

### Changes Made
- **Product ID 80 (I-22 Wireless Router)**: Shows "Orders of 10 or more grants 4-month delayed billing" at qty 10+
- **Product ID 647 (Cudy LT400 Wireless Router)**: Shows "Free ground shipping at qty 5" at qty 5+
- **Other products**: No longer receive universal shipping threshold messages

### Technical Implementation
- Modified `apw_woo_simulate_bulk_discount_thresholds()` function with product-specific conditional logic
- Added new 'billing' message type with amber/orange CSS styling
- Preserved existing `apply_filters` system for compatibility
- Updated plugin version to 1.24.16

### Files Modified
- `includes/apw-woo-dynamic-pricing-functions.php` - Core threshold logic
- `assets/css/apw-woo-threshold-messages.css` - New billing message styling  
- `apw-woo-plugin.php` - Version bump to 1.24.16

## Test Plan
- [ ] Test Product ID 80 at quantities 1-9 (no threshold messages for non-VIP users)
- [ ] Test Product ID 80 at qty 10+ (should show delayed billing message)
- [ ] Test Product ID 647 at quantities 1-4 (no threshold messages)
- [ ] Test Product ID 647 at qty 5+ (should show free shipping message)
- [ ] Test other product IDs (should show no shipping/billing threshold messages)
- [ ] Verify existing VIP and bulk discount notifications still work
- [ ] Verify CSS styling displays correctly for new 'billing' message type

## Breaking Changes
⚠️ **This removes universal shipping threshold messages** - only products 80 and 647 will now receive threshold notifications

🤖 Generated with [Claude Code](https://claude.ai/code)